### PR TITLE
Use highlight.js for syntax highlight

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@ TODO:
 
 - have the ability to link to other files
 - have an alert that asks if user wants to save changes when they navigate away
-- have syntax highlighting of code
 - have the ability to delete files and folders
 - maybe have a better markdown editor
 - create public API
@@ -20,3 +19,4 @@ FINISHED:
 - have different port support
 - have responsive design (just make it wider for larger screens)
 - change design of formatted markdown files (**especially for links**)
+- have syntax highlighting of code

--- a/lib/mdserver.js
+++ b/lib/mdserver.js
@@ -1,14 +1,25 @@
 var fs = require("fs");
 var path = require("path");
 var marked = require("marked");
+var hljs = require('highlight.js');
 var allowedExtensions = require("./allowedExtensions");
 var git = require("./git");
 var nodewiki = require("../nodewiki");
 
+var languageOverrides = {
+  js: 'javascript',
+  clj: 'clojure',
+  html: 'xml'
+}
+
 marked.setOptions({
-  gfm: true,
-  pendantic: false,
-  sanitize: true,
+  // gfm: true,
+  // pendantic: false,
+  // sanitize: true,
+  highlight: function(code, lang){
+    if(languageOverrides[lang]) lang = languageOverrides[lang];
+     return hljs.LANGUAGES[lang] ? hljs.highlight(lang, code).value : hljs.highlightAuto(code).value;
+  }
 });
 
 
@@ -30,7 +41,7 @@ function sendFile(file, directory, socket){
     socket.emit('readFileReply', {fileContents: "", error: {error: true, reason: "file requested is not a markdown file"}});
   }
 }
-
+ 
 function saveFile(file, directory, socket){
   if (allowedExtensions.checkExtension(file.name) == true && typeof file.content != 'undefined'){
     // only allow markdown files to be saved

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodewiki",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Nafis Hossain <nhoss2@gmail.com>",
   "description": "A simple wiki that uses markdown files",
   "license": "MIT",
@@ -16,8 +16,9 @@
   "dependencies": {
     "connect": "2.3.x",
     "socket.io": "0.9.x",
-    "marked": "0.2.x",
-    "posix-getopt": "1.0.x"
+    "marked": "0.2.9",
+    "posix-getopt": "1.0.x",
+	"highlight.js": "7.3.x"
   },
   "repository": {
     "type": "git",

--- a/static/index.html
+++ b/static/index.html
@@ -5,6 +5,7 @@
   <link rel="stylesheet" type="text/css" href="design/css.css">
   <link href='http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700,700italic' rel='stylesheet' type='text/css'>
   <link href='http://fonts.googleapis.com/css?family=PT+Mono' rel='stylesheet' type='text/css'>
+  <link rel="stylesheet" href="http://yandex.st/highlightjs/7.3/styles/default.min.css">
   <script type="text/javascript" src="/jquery.js"></script>
   <script type="text/javascript" src="/socketio.js"></script>
   <script type="text/javascript" src="/socket.io/socket.io.js"></script>


### PR DESCRIPTION
Added highlight.js dependency in package.json and its css file in index.html.
Will parse code block based on keyword or detect language automatically.
Since gfm is default for `marked`, I commented out the settings for `marked`
