### PR TITLE
ignoring the node_modules folder, message for empty directories

### DIFF
--- a/lib/getDir.js
+++ b/lib/getDir.js
@@ -46,6 +46,10 @@ function parseLinks(dir, dirDepth){
 
     var mdLinks = "";
 
+    if (dir.length === 0){
+      mdLinks += '<span class="link empty"><code>nothing here</code></span>\n';
+    }
+
     dir.forEach(function(fileName){
       if (fileName.markdown == true){
         mdLinks += '<a href="#" class="link"><code>' + fileName.name + '</code></a>\n';

--- a/lib/getDir.js
+++ b/lib/getDir.js
@@ -7,12 +7,14 @@ function getDir(directory){
     var currentFiles = fs.readdirSync(directory);
     var dir = [];
     currentFiles.forEach(function(fileName){
-      if (fs.statSync(directory + fileName).isDirectory() == true){
-        dir.push({name: fileName + '/', folder: true, markdown: false});
-      } else if (allowedExtensions.checkExtension(fileName) == true){
-        dir.push({name: fileName, folder: false, markdown: true});
-      } else {
-        dir.push({name: fileName, folder: false, markdown: false});
+      if( fileName !== "node_modules") {
+        if (fs.statSync(directory + fileName).isDirectory() == true){
+          dir.push({name: fileName + '/', folder: true, markdown: false});
+        } else if (allowedExtensions.checkExtension(fileName) == true){
+          dir.push({name: fileName, folder: false, markdown: true});
+        } else {
+          dir.push({name: fileName, folder: false, markdown: false});
+        }
       }
 
     });

--- a/static/design/css.css
+++ b/static/design/css.css
@@ -164,7 +164,7 @@ code {
   box-shadow: 0px 0px 0px 1px #000000;
   overflow: hidden;
 }
-#navigation a.link {
+#navigation .link {
   color: #fff;
   text-decoration: none;
   padding: 10px 10px 10px 15px;
@@ -172,16 +172,20 @@ code {
   border-bottom: 1px solid #060606;
   border-top: 1px solid #353536;
 }
-#navigation a.link:first-child {
+#navigation .link:first-child {
   border-top: none;
   border-radius: 7px 0 0 0;
   -webkit-box-radius: 7px 0 0 0;
 }
-#navigation a.link:last-child {
+#navigation .link:last-child {
   border-bottom: none;
 }
-#navigation a.link code {
+#navigation .link code {
   font-size: 14px;
+}
+#navigation .empty {
+  color: #ececec;
+  font-style: italic;
 }
 #navigation a {
   outline: none;

--- a/static/design/css.less
+++ b/static/design/css.less
@@ -177,7 +177,7 @@ code{
   box-shadow: 0px 0px 0px 1px #000000;
   overflow: hidden;
 
-  a.link{
+  .link{
     color: #fff;
     text-decoration: none;
     padding: 10px 10px 10px 15px;
@@ -198,6 +198,11 @@ code{
     code{
       font-size: 14px;
     }
+  }
+
+  .empty{
+    color: #ececec;
+    font-style: italic;
   }
 
   a{


### PR DESCRIPTION
This is all pretty inconsequential, but it started out as a bigger effort, and I thought I might as well pass off the tidbits that did end up getting finished.

Now people can run `nodewiki` in the wiki root and not see the **node_modules** folder.  Nodewiki will also now show a message for empty folders.
