### PR TITLE
Newwiki fix install

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,13 +25,13 @@ automatically does a git commit on each file save.
 
 Node Wiki can be started on any directory. To start it, simply type
 `nodewiki` in the directory that you want to start it in. Without any
-options, the URL for node wiki would be: http://<Hostname_or_IP>:8888/
+options, the URL for node wiki would be: http://<Hostname_or_IP>:3000/
 and any other computer on the network can access the wiki (subject to
 firewall settings).
 
 If you do not want other computers to be able to access node wiki, then
 use `--local` or `--port=127.0.0.1`. The URL for node wiki will then be
-http://localhost:8888/.
+http://localhost:3000/.
 
 If your computer is connected to a network, then the `--local` option is
 highly recommended.
@@ -61,8 +61,8 @@ Display a short help message.
 `--port=<port>`  
 `--port <port>`  
 `<port>` (depricated)  
-Listen on <port> rather than 8888. The default port can be changed
-from 8888 by setting the PORT environment variable.
+Listen on <port> rather than 3000. The default port can be changed
+from 3000 by setting the PORT environment variable.
 
 ###Examples
 
@@ -74,7 +74,7 @@ Starts node wiki in git mode, listening on only 127.0.0.1 (localhost).
 
 `nodewiki --git --local --port=9876`  
 Starts node wiki in git mode, listening on port 9876, of 127.0.0.1,
-rather than the default port, 8888.
+rather than the default port, 3000.
 
 `nodewiki -glp 9876`  
 Same as the above, but using short form options.

--- a/Readme.md
+++ b/Readme.md
@@ -20,18 +20,30 @@ automatically does a git commit on each file save.
 
 ## Usage
 
-    nodewiki
+    nodewiki [port]
 
 Node Wiki can be started on any directory. To start it, simply type
 `nodewiki` in the directory that you want to start it in. Without any
 options, the URL for node wiki would be: http://<Hostname_or_IP>:3000/
 and any other computer on the network can access the wiki (subject to
-firewall settings). To specify the port set the environment varialbe `PORT`.
+firewall settings). To specify the port either give it as the first 
+argument on the command line or, set the environment varialbe `PORT`.
+
+The command line port argument overrides the environment variable PORT 
+so, you can use nodewiki even if you're already using your environment 
+variable for something else!
 
 ###Examples
 
-`nodewiki`  
+```
+nodewiki
+``` 
 Starts node wiki
+
+```
+nodewiki 7777
+```
+Starts node wiki on port 7777
 
 ```
 SET PORT 8888

--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,6 @@ started in so it is possible to use text editors to edit the files.
 Version control is done through git. There is a git mode which
 automatically does a git commit on each file save.
 
-
 ## Install
 
     npm install nodewiki -g
@@ -21,63 +20,21 @@ automatically does a git commit on each file save.
 
 ## Usage
 
-    nodewiki [options]
+    nodewiki
 
 Node Wiki can be started on any directory. To start it, simply type
 `nodewiki` in the directory that you want to start it in. Without any
 options, the URL for node wiki would be: http://<Hostname_or_IP>:3000/
 and any other computer on the network can access the wiki (subject to
-firewall settings).
-
-If you do not want other computers to be able to access node wiki, then
-use `--local` or `--port=127.0.0.1`. The URL for node wiki will then be
-http://localhost:3000/.
-
-If your computer is connected to a network, then the `--local` option is
-highly recommended.
-
-
-###Options
-`-a <IPv4_addr>`  
-`--addr=<IPv4_addr>`  
-`--addr <IPv4_addr>`  
-Listen only on IPv4_addr. The listen address can also be specified by defining NW_ADDR in the environment.
-
-`-l`  
-`--local`  
-Listen on localhost only. This is equivalent to `--addr=127.0.0.1`.
-
-`-g`  
-`--git`  
-`git` (depricated)  
-Commit each save to a git repository.
-
-`-h`  
-`--help`  
-`help` (depricated)  
-Display a short help message.
-
-`-p <port>`  
-`--port=<port>`  
-`--port <port>`  
-`<port>` (depricated)  
-Listen on <port> rather than 3000. The default port can be changed
-from 3000 by setting the PORT environment variable.
+firewall settings). To specify the port set the environment varialbe `PORT`.
 
 ###Examples
 
 `nodewiki`  
 Starts node wiki
 
-`nodewiki --git --local`  
-Starts node wiki in git mode, listening on only 127.0.0.1 (localhost).
-
-`nodewiki --git --local --port=9876`  
-Starts node wiki in git mode, listening on port 9876, of 127.0.0.1,
-rather than the default port, 3000.
-
-`nodewiki -glp 9876`  
-Same as the above, but using short form options.
-
-`nodewiki --help`  
-Displays node wiki usage.
+```
+SET PORT 8888
+nodewiki
+```
+Starts node wiki on port 8888

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,10 +5,10 @@ var NodeWiki = require('../nodewiki');
 
 var wiki = new NodeWiki();
 
-wiki.app.set('port', process.env.PORT || 3000);
+wiki.app.set('port', process.argv[2] || process.env.PORT || 3000);
 
 var server = http.createServer(wiki.app);
 
 server.listen(wiki.app.get('port'), function(){
-  console.log('Node Wiki started');
+  console.log('Node Wiki started at http://localhost:' + wiki.app.get('port'));
 });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "bin/cli.js"
   },
   "main": "nodewiki.js",
-  "bin": "./nodewiki.js",
+  "bin": "bin/cli.js",
   "dependencies": {
     "async": "^0.8.0",
     "body-parser": "~1.0.0",


### PR DESCRIPTION
My buddy @denolfe was trying to get the newwiki branch working earlier today but it kept erroring out. I had some time so I took a look at it and made some fixes. The bin property of package.json was pointing to the wrong place and none of the command line arguments worked. I fixed it so that the nodewiki command will work and the port can be specified on the command line, then I updated the readme to reflect nodewiki's current state.
